### PR TITLE
Add links for Counter and HTML tools

### DIFF
--- a/index.htm
+++ b/index.htm
@@ -239,6 +239,16 @@
         <p>PHP API to store and retrieve data.</p>
         <a href="https://github.com/llagerlof/freezer" target="_blank" class="btn">View on GitHub</a>
       </div>
+      <div class="card">
+        <h3><span class="card-icon">🔢</span>Counter</h3>
+        <p>Count characters, words and lines in text.</p>
+        <a href="tools/counter/index.html" class="btn">Open</a>
+      </div>
+      <div class="card">
+        <h3><span class="card-icon">💻</span>HTML Live Editor</h3>
+        <p>Realtime HTML, CSS and JavaScript preview.</p>
+        <a href="tools/html/index.html" class="btn">Open</a>
+      </div>
     </div>
   </section>
   


### PR DESCRIPTION
## Summary
- link new Counter and HTML tools under **Web Tools**

## Testing
- `git log -1 --stat`

------
https://chatgpt.com/codex/tasks/task_e_6866b8e2d650832a930aa084f24a346f